### PR TITLE
Add 1h system prompt cache TTL and cache breakpoint logging

### DIFF
--- a/packages/python/analytiq_data/llm/llm.py
+++ b/packages/python/analytiq_data/llm/llm.py
@@ -24,8 +24,10 @@ litellm.drop_params = True
 # When thinking_blocks missing in assistant msg, drop thinking param (Anthropic + tools workaround)
 litellm.modify_params = True
 
-# Cache control directive for Anthropic/Bedrock prompt caching (ephemeral cache)
-_PROMPT_CACHE_CONTROL = {"type": "ephemeral"}
+# Cache control directive for Anthropic/Bedrock prompt caching (ephemeral cache).
+# Explicit 1h TTL requested for system prompt caching.
+_PROMPT_CACHE_CONTROL = {"type": "ephemeral", "ttl": "1h"}
+_DEFAULT_CACHE_BREAKPOINT_TTL = "5m"
 
 
 def _get_int_env(name: str, default: int) -> int:
@@ -44,6 +46,24 @@ def _is_valid_json(s: str) -> bool:
         return True
     except (ValueError, TypeError):
         return False
+
+
+def _cache_breakpoint_ttl(cache_control: Optional[Dict[str, Any]]) -> str:
+    """Return cache breakpoint TTL; default to 5m when not explicitly set."""
+    if isinstance(cache_control, dict):
+        ttl = cache_control.get("ttl")
+        if isinstance(ttl, str) and ttl.strip():
+            return ttl.strip()
+    return _DEFAULT_CACHE_BREAKPOINT_TTL
+
+
+def _append_cache_breakpoint(text: str, cache_control: Optional[Dict[str, Any]]) -> str:
+    """
+    Annotate a printed prompt component with a cache breakpoint marker.
+    This affects only prompt logging/debug output, not model payload content.
+    """
+    ttl = _cache_breakpoint_ttl(cache_control)
+    return f"{text.rstrip()}\n[cache_breakpoint ttl={ttl}]"
 
 
 def _apply_prompt_caching(model: str, messages: list, *, tools: Optional[List[Dict]] = None) -> list:
@@ -628,7 +648,7 @@ def _prompt_used_from_grouped_user_blocks(
     # Build prompt_used by dispatching based on block content (OCR/PDF prefixes),
     # instead of walking by index position. This makes the placeholder build
     # resilient to future include toggles / inserted blocks.
-    parts: List[str] = [system_prompt.rstrip(), ""]
+    parts: List[str] = [_append_cache_breakpoint(system_prompt, _PROMPT_CACHE_CONTROL), ""]
 
     doc_ptr = -1
     current_doc_id_str: str | None = None

--- a/packages/python/tests/test_llm.py
+++ b/packages/python/tests/test_llm.py
@@ -316,7 +316,7 @@ def test_apply_prompt_caching_converts_system_string_when_supported():
     assert len(out[0]["content"]) == 1
     assert out[0]["content"][0]["type"] == "text"
     assert out[0]["content"][0]["text"] == "You are a helpful assistant."
-    assert out[0]["content"][0]["cache_control"] == {"type": "ephemeral"}
+    assert out[0]["content"][0]["cache_control"] == {"type": "ephemeral", "ttl": "1h"}
     assert out[1] == {"role": "user", "content": "Hello"}
 
 
@@ -375,7 +375,17 @@ def test_apply_prompt_caching_applied_for_claude_when_tools_passed():
         tools = [{"type": "function", "function": {"name": "test", "description": "test"}}]
         out = _apply_prompt_caching("anthropic/claude-sonnet-4-5-20250929", messages, tools=tools)
     assert len(out) == 2
-    assert out[0]["content"][0]["cache_control"] == {"type": "ephemeral"}
+    assert out[0]["content"][0]["cache_control"] == {"type": "ephemeral", "ttl": "1h"}
+
+
+def test_cache_breakpoint_ttl_defaults_to_5m():
+    """Prompt component cache breakpoint TTL defaults to 5m when missing."""
+    from analytiq_data.llm.llm import _cache_breakpoint_ttl
+
+    assert _cache_breakpoint_ttl(None) == "5m"
+    assert _cache_breakpoint_ttl({}) == "5m"
+    assert _cache_breakpoint_ttl({"type": "ephemeral"}) == "5m"
+    assert _cache_breakpoint_ttl({"type": "ephemeral", "ttl": "1h"}) == "1h"
 
 
 @pytest.mark.asyncio

--- a/packages/python/tests/test_llm_prompt_context.py
+++ b/packages/python/tests/test_llm_prompt_context.py
@@ -401,6 +401,7 @@ def test_prompt_used_from_grouped_user_blocks_placeholders():
     ]
     out = _prompt_used_from_grouped_user_blocks(system, user_blocks, ordered, True, True)
     assert out.startswith("SYS")
+    assert "[cache_breakpoint ttl=1h]" in out
     assert f"ocr_text:\n<{d0}_ocr_text>" in out
     assert f"ocr_text:\n<{d1}_ocr_text>" in out
     assert f"pdf:\n<{d1}_pdf>" in out


### PR DESCRIPTION
## Summary
- set Anthropic/Bedrock system prompt cache control to include `ttl: \"1h\"` so cached system prompts use a longer explicit TTL
- add prompt-log helpers to annotate printed prompt components with cache breakpoint markers, including TTL (`[cache_breakpoint ttl=...]`)
- default cache breakpoint TTL rendering to `5m` when no explicit TTL is present, and update tests to cover both the new cache control payload and breakpoint rendering

## Test plan
- [ ] Run `pytest -q packages/python/tests/test_llm.py -k \"prompt_caching or cache_breakpoint_ttl\"`
- [ ] Run `pytest -q packages/python/tests/test_llm_prompt_context.py -k \"prompt_used_from_grouped_user_blocks_placeholders\"`
- [ ] Verify logs now show `system[0] cache_control={\"type\": \"ephemeral\", \"ttl\": \"1h\"}` and include `[cache_breakpoint ttl=1h]`

## Notes
- I could not run pytest locally in this environment because `pytest_asyncio` is not installed (`ModuleNotFoundError: No module named 'pytest_asyncio'`).

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to LLM prompt caching metadata (adds explicit TTL) and debug/log rendering of `prompt_used`, with unit test updates covering the new behavior.
> 
> **Overview**
> Sets Anthropic/Bedrock system prompt caching to include an explicit `ttl: "1h"` in the `cache_control` block sent via `_apply_prompt_caching`.
> 
> Adds helpers to annotate the rendered `prompt_used`/prompt logs with a `[cache_breakpoint ttl=…]` marker (defaulting to `5m` when no TTL is provided), and updates/extends tests to assert the new cache-control payload and breakpoint rendering.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a334743c4c58cf1468718afb3404dc7bc733db15. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->